### PR TITLE
Remove quotations from logging output

### DIFF
--- a/pynab/__init__.py
+++ b/pynab/__init__.py
@@ -17,4 +17,4 @@ if config.site['logging_file']:
     handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
     log.addHandler(handler)
 else:
-    logging.basicConfig(format='"%(asctime)s - %(levelname)s - %(message)s"')
+    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
The quotation marks in the logging seem to just take up with without semantic purpose.  This removes them from the logging format string.
