### PR TITLE
Remove conflict lines from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-<<<<<<< HEAD
 
 # Complexity
 output/*.html
@@ -26,10 +25,10 @@ output/*/index.html
 
 # Sphinx
 docs/_build
-=======
->>>>>>> c8832d265f1a0a95c4e45ede938a4d1cda54e204
 
 # pycharm
 .idea
 
+build/
 config.py
+logs


### PR DESCRIPTION
Not that its very impactful, but I noticed the gitignore had conflict markers.  I also added build/ and logs/ since I thought they'd be useful.
