### PR TITLE
Add favicon endpoint to api.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -60,6 +60,10 @@ def index():
 	if config.site['webui']:
 	    raise bottle.static_file('index.html', root='./webui/dist')
 
+@app.get('/favicon.ico')
+def index():
+	if config.site['webui']:
+	    raise bottle.static_file('favicon.ico', root='./webui/dist')
 
 def switch_output(data):
     output_format = request.query.o or 'xml'


### PR DESCRIPTION
I'm a sucker for favicons, and I sorta hate seeing 404s in my api logs for normal browser usage (I ignore all the weird 400/500's caused by hackers and scripts).  This adds the endpoint to return a favicon.
