### PR TITLE
tvrage parser rewritten with lxml

### DIFF
--- a/tests/test_tvrage.py
+++ b/tests/test_tvrage.py
@@ -1,0 +1,20 @@
+import logging
+import time
+import unittest
+
+from pynab.db import db
+from pynab import tvrage 
+
+
+tvrage.log.setLevel(logging.DEBUG)
+
+class TestTvRage(unittest.TestCase):
+    def test_search(self):
+        for release in db.releases.find({'tvrage.possible': {'$exists': False}}):
+            show = tvrage.parse_show(release['search_name'])
+            if show:
+                rage_data = tvrage.search(show)
+                time.sleep(1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Rewrite tvrage search parsing using lxml instead of xmltodict. It is way faster and simpler (150% to 1500% speedup on my rig, ~250% average).
It should result the same result as the xmltodict implementation,
however at this time both implementation are tried against the tvrage
xml result, then results are compared. This way we'll make sure that the
lxml implementation is as accurate as xmltodict, then remove xmltodict.

Also, added new simple test to try to search again all show releases in
the db, even if already attempted.
