### PR TITLE
Fix for postgres 9.4

### DIFF
--- a/pynab/api.py
+++ b/pynab/api.py
@@ -148,7 +148,8 @@ def tv_search(dataset=None):
                 episode = request.query.ep or None
 
                 if season or episode:
-                    query = query.join(Episode, Release)
+                    release_alias = aliased(Release)
+                    query = query.join(Episode, release_alias)
 
                     if season:
                         # 2014, do nothing


### PR DESCRIPTION
I got this error when using postgres 9.4:

`sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) table name "releases" specified more than once...`

Probably due to [Re: Re: BUG #8444: ERROR: table name "tblb" specified more than once in subquery](http://www.postgresql.org/message-id/1080.1379085600@sss.pgh.pa.us) which is apparently not a bug but an intentional change from postgres 9.3 and onwards.