### PR TITLE
Code to expire releases older than a certain number of days.

### DIFF
--- a/config_sample.py
+++ b/config_sample.py
@@ -251,6 +251,11 @@ postprocess = {
     # set it to 3 or so for normal operation
     'delete_blacklisted_days': 3,
 
+    # release_expiry_days: expire releases older than this many days.
+    # set to a value of 0 if you do not want to expire at all
+    # default value is 0
+    'release_expiry_days': 0,
+
     # process_movies: list of interfaces to post-process movies against
     # couchpotato sometimes depends on this data for API usage, definitely recommended
     # options: ['OMDB']

--- a/postprocess.py
+++ b/postprocess.py
@@ -174,31 +174,41 @@ def main():
                 db.commit()
                 """
 
+            if config.postprocess.get('release_expiry_days', 0) > 0:
+                expire_days = config.postprocess.get('release_expiry_days', 0)
+                log.info('postprocess: expiring releases posted more than {} days ago.'.format(expire_days))
+                deleted_releases = db.query(Release).filter(Release.posted < (datetime.datetime.now(pytz.utc) - datetime.timedelta(days=expire_days))).delete(synchronize_session='fetch')
+                log.info('postprocess: expired {} releases'.format(deleted_releases))
+
             # delete any orphan metablacks
             log.info('postprocess: deleting orphan metablacks...')
             # noinspection PyComparisonWithNone,PyComparisonWithNone,PyComparisonWithNone,PyComparisonWithNone,PyComparisonWithNone
-            db.query(MetaBlack).filter(
+            deleted_metablacks = db.query(MetaBlack).filter(
                 (MetaBlack.movie == None) &
                 (MetaBlack.tvshow == None) &
                 (MetaBlack.rar == None) &
                 (MetaBlack.nfo == None) &
                 (MetaBlack.sfv == None)
             ).delete(synchronize_session='fetch')
+            log.info('postprocess: deleted {} orphaned metablacks.'.format(deleted_metablacks))
 
             # delete any orphan nzbs
             log.info('postprocess: deleting orphan nzbs...')
             # noinspection PyComparisonWithNone
-            db.query(NZB.id).filter(NZB.release == None).delete(synchronize_session='fetch')
+            deleted_nzbs = db.query(NZB.id).filter(NZB.release == None).delete(synchronize_session='fetch')
+            log.info('postprocess: deleted {} orphaned nzbs.'.format(deleted_nzbs))
 
             # delete any orphan nfos
             log.info('postprocess: deleting orphan nfos...')
             # noinspection PyComparisonWithNone
-            db.query(NFO.id).filter(NFO.release == None).delete(synchronize_session='fetch')
+            deleted_nfos = db.query(NFO.id).filter(NFO.release == None).delete(synchronize_session='fetch')
+            log.info('postprocess: deleted {} orphaned nfos.'.format(deleted_nfos))
 
             # delete any orphan sfvs
             log.info('postprocess: deleting orphan sfvs...')
             # noinspection PyComparisonWithNone
-            db.query(SFV.id).filter(SFV.release == None).delete(synchronize_session='fetch')
+            deleted_sfvs = db.query(SFV.id).filter(SFV.release == None).delete(synchronize_session='fetch')
+            log.info('postprocess: deleted {} orphaned sfvs.'.format(deleted_sfvs))
 
             db.commit()
 


### PR DESCRIPTION
This implements #241 during postprocessing.  The expiration happens right before the orphan deletes so that orphaned data gets cleaned up automagically.

I also added a bit of extra logging around the orphan deletes to give a better picture of what was going on.