### PR TITLE
Lock pytvmaze version to 1.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ colorama
 pandas
 beautifulsoup4
 pySmartDL
-pytvmaze
+pytvmaze<2.0
 git+https://github.com/PyMySQL/PyMySQL.git
 nltk
 


### PR DESCRIPTION
Given pytvmaze has a 2.\* major version, the pynab dep should be locked to 1.\* releases since it doesn't support the new API.
