### PR TITLE
Lock pytvmaze version to 1.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ colorama
 pandas
 beautifulsoup4
 pySmartDL
-pytvmaze
+pytvmaze<2.0
 git+https://github.com/PyMySQL/PyMySQL.git
 nltk
 jaraco.itertools


### PR DESCRIPTION
Locks the pytvmaze version to 1.\* releases to prevent installs from using the new 2.0 API.
