### PR TITLE
Update regex version to match what is available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ xmltodict
 pynzb
 requests
 roman>=2.0.0
-regex==2.4.44
+regex==2014.05.17
 lxml
 daemonize
 colorlog


### PR DESCRIPTION
Seems that the numbered versions are no longer available for a pip install so switch to the new versioning scheme.  This should fix #273.